### PR TITLE
change semantics w.r.t. synergy between --from-pr and specified easyconfigs

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -249,17 +249,23 @@ def det_easyconfig_paths(orig_paths, from_pr=None, easyconfigs_pkg_paths=None):
     if easyconfigs_pkg_paths is None:
         easyconfigs_pkg_paths = []
 
-    pr_files = None
+    # list of specified easyconfig files
+    ec_files = orig_paths[:]
+
     if from_pr is not None:
         pr_files = fetch_easyconfigs_from_pr(from_pr)
 
-    ec_files = orig_paths[:]
+        if ec_files:
+            # replace paths for specified easyconfigs that are touched in PR
+            for i, ec_file in enumerate(ec_files):
+                for pr_file in pr_files:
+                    if ec_file == os.path.basename(pr_file):
+                        ec_files[i] = pr_file
+        else:
+            # if no easyconfigs are specified, use all the ones touched in the PR
+            ec_files = [path for path in pr_files if path.endswith('.eb')]
 
-    if not ec_files and pr_files:
-        ec_files = [path for path in pr_files if path.endswith('.eb')]
-    elif ec_files and pr_files:
-        ec_files = [path for path in pr_files if os.path.basename(path) in orig_paths]
-    elif ec_files and easyconfigs_pkg_paths:
+    if ec_files and easyconfigs_pkg_paths:
         # look for easyconfigs with relative paths in easybuild-easyconfigs package,
         # unless they were found at the given relative paths
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -747,9 +747,22 @@ class CommandLineOptionsTest(EnhancedTestCase):
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
+        orig_sys_path = sys.path[:]
+
+        # adjust PYTHONPATH such that test easyblocks are found
+        # this is required since the HPL and ScaLAPACK easyconfigs included in the tested PR have no 'easyblock' spec
+        import easybuild
+        eb_blocks_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'sandbox'))
+        if not eb_blocks_path in sys.path:
+            sys.path.append(eb_blocks_path)
+            easybuild = reload(easybuild)
+
+        import easybuild.easyblocks
+        reload(easybuild.easyblocks)
+
         tmpdir = tempfile.mkdtemp()
         args = [
-            # PR for intel/2014b, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
+            # PR for foss/2015a, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
             '--from-pr=1239',
             '--dry-run',
             # an argument must be specified to --robot, since easybuild-easyconfigs may not be installed
@@ -783,6 +796,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         except URLError, err:
             print "Ignoring URLError '%s' in test_from_pr" % err
             shutil.rmtree(tmpdir)
+
+        sys.path = orig_sys_path
 
     def test_no_such_software(self):
         """Test using no arguments."""

--- a/test/framework/sandbox/easybuild/easyblocks/hpl.py
+++ b/test/framework/sandbox/easybuild/easyblocks/hpl.py
@@ -1,0 +1,33 @@
+##
+# Copyright 2009-2014 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Dummy easyblock for HPL
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from easybuild.framework.easyblock import EasyBlock
+
+class EB_HPL(EasyBlock):
+    pass

--- a/test/framework/sandbox/easybuild/easyblocks/scalapack.py
+++ b/test/framework/sandbox/easybuild/easyblocks/scalapack.py
@@ -1,0 +1,33 @@
+##
+# Copyright 2009-2014 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Dummy easyblock for ScaLAPACK
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from easybuild.framework.easyblock import EasyBlock
+
+class EB_ScaLAPACK(EasyBlock):
+    pass


### PR DESCRIPTION
current behaviour:

```
$ eb --from-pr 1287 GCC-4.8.2.eb horton-1.0.2-goolf-1.4.10-Python-2.7.3.eb -D | egrep "/GCC|horton|Libint"
 * [x] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb (module: GCC/4.8.2)
 * [ ] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb (module: GCC/4.7.2)
 * [ ] /tmp/files_pr1287/Libint-2.0.3-goolf-1.4.10.eb (module: Libint/2.0.3-goolf-1.4.10)
 * [ ] /tmp/files_pr1287/horton-1.0.2-goolf-1.4.10-Python-2.7.3.eb (module: horton/1.0.2-goolf-1.4.10-Python-2.7.3)
```

```
$ eb --from-pr 1287 GCC-4.8.2.eb -D | egrep "/GCC|horton|Libint" 
CFGS=/Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC
 * [x] $CFGS/GCC-4.8.2.eb (module: GCC/4.8.2)
```

```
$ eb --from-pr 1287 -D | egrep "/GCC|horton|Libint" 
 * [ ] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb (module: GCC/4.7.2)
 * [ ] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb (module: GCC/4.6.3)
 * [ ] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb (module: GCC/4.8.3)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-goolf-1.4.10.eb (module: Libint/1.1.4-goolf-1.4.10)
 * [ ] /tmp/files_pr1287/Libint-2.0.3-goolf-1.4.10.eb (module: Libint/2.0.3-goolf-1.4.10)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-ictce-3.2.2.u3.eb (module: Libint/1.1.4-ictce-3.2.2.u3)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-ictce-4.1.13.eb (module: Libint/1.1.4-ictce-4.1.13)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-ictce-5.3.0.eb (module: Libint/1.1.4-ictce-5.3.0)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-ictce-5.5.0.eb (module: Libint/1.1.4-ictce-5.5.0)
 * [ ] /tmp/files_pr1287/Libint-2.0.3-ictce-4.1.13.eb (module: Libint/2.0.3-ictce-4.1.13)
 * [ ] /tmp/files_pr1287/Libint-2.0.3-ictce-5.5.0.eb (module: Libint/2.0.3-ictce-5.5.0)
 * [ ] /tmp/files_pr1287/Libint-2.0.3-intel-2014b.eb (module: Libint/2.0.3-intel-2014b)
 * [ ] /tmp/files_pr1287/horton-1.0.2-goolf-1.4.10-Python-2.7.3.eb (module: horton/1.0.2-goolf-1.4.10-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.1.0-goolf-1.4.10-Python-2.7.3.eb (module: horton/1.1.0-goolf-1.4.10-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.2.0-goolf-1.4.10-Python-2.7.3.eb (module: horton/1.2.0-goolf-1.4.10-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.2.1-goolf-1.4.10-Python-2.7.3.eb (module: horton/1.2.1-goolf-1.4.10-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.0.2-ictce-4.1.13-Python-2.7.3.eb (module: horton/1.0.2-ictce-4.1.13-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.1.0-ictce-4.1.13-Python-2.7.3.eb (module: horton/1.1.0-ictce-4.1.13-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.2.0-ictce-4.1.13-Python-2.7.3.eb (module: horton/1.2.0-ictce-4.1.13-Python-2.7.3)
 * [ ] /tmp/files_pr1287/horton-1.2.1-ictce-4.1.13-Python-2.7.3.eb (module: horton/1.2.1-ictce-4.1.13-Python-2.7.3)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-gmacml-1.7.0.eb (module: Libint/1.1.4-gmacml-1.7.0)
 * [ ] /tmp/files_pr1287/Libint-1.1.4-goalf-1.1.0-no-OFED.eb (module: Libint/1.1.4-goalf-1.1.0-no-OFED)
```
