### PR TITLE
enhance test for 'which'

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -149,6 +149,14 @@ class FileToolsTest(EnhancedTestCase):
         path = ft.which('i_really_do_not_expect_a_command_with_a_name_like_this_to_be_available')
         self.assertTrue(path is None)
 
+        os.environ['PATH'] = '%s:%s' % (self.test_prefix, os.environ['PATH'])
+        foo, bar = os.path.join(self.test_prefix, 'foo'), os.path.join(self.test_prefix, 'bar')
+        ft.mkdir(foo)
+        ft.adjust_permissions(foo, stat.S_IRUSR|stat.S_IXUSR)
+        ft.write_file(bar, '#!/bin/bash')
+        ft.adjust_permissions(bar, stat.S_IRUSR|stat.S_IXUSR)
+        self.assertEqual(ft.which('foo'), None)
+        self.assertTrue(os.path.samefile(ft.which('bar'), bar))
 
     def test_checksums(self):
         """Test checksum functionality."""


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/1921

fails on current `develop` with:

```
FAIL: test_which (__main__.FileToolsTest)
Test which function for locating commands.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/filetools.py", line 158, in test_which
    self.assertEqual(ft.which('foo'), None)
  File "/Users/kehoste/work/vsc-install/lib/vsc/install/testing.py", line 79, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: '/var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-4tez51/eb-AkZo4Q/foo' != None:
DIFF:
- /var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-4tez51/eb-AkZo4Q/foo

----------------------------------------------------------------------
Ran 1 test in 0.390s

FAILED (failures=1)
```
