### PR TITLE
finish --check-style

### DIFF
--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -28,10 +28,10 @@ Style tests for easyconfig files using pep8.
 
 :author: Ward Poelmans (Ghent University)
 """
-
 import re
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import print_msg
 from easybuild.tools.utilities import only_if_module_is_available
 
 try:
@@ -124,3 +124,23 @@ def check_easyconfigs_style(easyconfigs, verbose=False):
         result.print_statistics()
 
     return result.total_errors
+
+
+def cmdline_easyconfigs_style_check(paths):
+    """
+    Run easyconfigs style check of each of the specified paths, triggered from 'eb' command line
+
+    :param paths: list of paths to easyconfig files to check
+    :return: True when style check passed on all easyconfig files, False otherwise
+    """
+    print_msg("Running style check on %d easyconfig(s)..." % len(paths), prefix=False)
+    style_check_passed = True
+    for path in paths:
+        if check_easyconfigs_style([path]) == 0:
+            res = 'PASS'
+        else:
+            res = 'FAIL'
+            style_check_passed = False
+        print_msg('[%s] %s' % (res, path), prefix=False)
+
+    return style_check_passed

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -50,7 +50,7 @@ import easybuild.tools.config as config
 import easybuild.tools.options as eboptions
 from easybuild.framework.easyblock import EasyBlock, build_and_install_one
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
-from easybuild.framework.easyconfig.style import check_easyconfigs_style
+from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
 from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, categorize_files_by_type, dep_graph
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
 from easybuild.framework.easyconfig.tools import parse_easyconfigs, review_pr, skip_available
@@ -325,14 +325,14 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
             _log.info("Regression test failed (partially)!")
             sys.exit(31)  # exit -> 3x1t -> 31
 
-    if options.check_easyconfigs_style:
-        _log.debug("Running style check")
-        if check_easyconfigs_style([path[0] for path in paths]) != 0:
-            print_error("Style check failed", log=_log)
-        else:
-            print_msg("Style check passed")
+    if options.check_style:
+        _log.debug("Running style check...")
+        if cmdline_easyconfigs_style_check([path[0] for path in paths]):
+            print_msg("All style checks passed!", prefix=False)
             cleanup(logfile, eb_tmpdir, testing)
             sys.exit(0)
+        else:
+            raise EasyBuildError("One or more style checks FAILED!")
 
     # read easyconfig files
     easyconfigs, generated_ecs = parse_easyconfigs(paths)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -513,6 +513,7 @@ class EasyBuildOptions(GeneralOption):
 
         opts = OrderedDict({
             'check-github': ("Check status of GitHub integration, and report back", None, 'store_true', False),
+            'check-style': ("Run a style check on the given easyconfigs", None, 'store_true', False),
             'dump-test-report': ("Dump test report to specified path", None, 'store_or_None', 'test_report.md'),
             'from-pr': ("Obtain easyconfigs from specified PR", int, 'store', None, {'metavar': 'PR#'}),
             'git-working-dirs-path': ("Path to Git working directories for EasyBuild repositories", str, 'store', None),
@@ -533,7 +534,6 @@ class EasyBuildOptions(GeneralOption):
                                        None, 'regex', None),
             'update-pr': ("Update an existing pull request", int, 'store', None, {'metavar': 'PR#'}),
             'upload-test-report': ("Upload full test report as a gist on GitHub", None, 'store_true', False, 'u'),
-            'check-easyconfigs-style': ("Run a style check on the given easyconfigs", None, 'store_true', False),
         })
 
         self.log.debug("github_options: descr %s opts %s" % (descr, opts))


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/2038

* rename --check-easyconfigs-style to --check-style
* be more verbose
* flesh out hard work to dedicated function
* add dedicated test

Example output:

```
$ eb --check-style bzip2-1.0.6.eb
== temporary log file in case of crash /tmp/eb-vRjS5T/easybuild-5F3HbZ.log
Running style check on 1 easyconfig(s)...
[PASS] /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
All style checks passed!
== Temporary log file(s) /tmp/eb-vRjS5T/easybuild-5F3HbZ.log* have been removed.
== Temporary directory /tmp/eb-vRjS5T has been removed.
```

```
$ eb --check-style test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
== temporary log file in case of crash /tmp/eb-7Kx3iJ/easybuild-CAv1Vr.log
Running style check on 1 easyconfig(s)...
/Users/kehoste/work/easybuild-framework/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb:1:13: W299 trailing whitespace
[FAIL] /Users/kehoste/work/easybuild-framework/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
ERROR: One or more style checks FAILED!
```